### PR TITLE
Strip old `set-cookie` header when replacing with encrypted

### DIFF
--- a/securecookies/middleware.py
+++ b/securecookies/middleware.py
@@ -139,7 +139,7 @@ class SecureCookiesMiddleware(BaseHTTPMiddleware):
         response: Response = await call_next(request)
 
         # Extract the cookie header to be mutated later
-        cookie_headers = response.headers.getlist("set-cookie").copy()
+        cookie_headers = response.headers.getlist("set-cookie")
         del response.headers["set-cookie"]
 
         for cookie_header in cookie_headers:

--- a/tests/test_securecookies.py
+++ b/tests/test_securecookies.py
@@ -17,6 +17,10 @@ def test_bad_samesite(client_factory):
         client = client_factory(cookie_samesite="invalid")
         client.get("/get")
 
+    with pytest.warns(UserWarning, match="Insecure"):
+        client = client_factory(cookie_secure=False, cookie_samesite="None")
+        client.get("/get")
+
 
 def test_outgoing(client_factory, fernet):
     # api write ginger-molasses, client needs to decrypt

--- a/tests/test_securecookies.py
+++ b/tests/test_securecookies.py
@@ -23,6 +23,7 @@ def test_outgoing(client_factory, fernet):
     response = client_factory().get("/get")
     assert response.status_code == 200
 
+    assert len(response.headers.get_list("set-cookie")) == 1
     cookie = response.cookies["type"]
     assert fernet.decrypt(cookie.encode()).decode() == "ginger-molasses"
     assert not next(iter(response.cookies.jar)).secure
@@ -45,6 +46,7 @@ def test_outgoing_included(client_factory, fernet):
     response = client.get("/getm")
 
     assert response.status_code == 200
+    assert len(response.headers.get_list("set-cookie")) == 2
     assert (
         fernet.decrypt(response.cookies["type"].encode()).decode() == "ginger-molasses"
     )
@@ -57,6 +59,7 @@ def test_outgoing_excluded(client_factory, fernet):
     response = client.get("/getm")
     assert response.status_code == 200
 
+    assert len(response.headers.get_list("set-cookie")) == 2
     cookie = response.cookies["anothertype"]
     assert fernet.decrypt(cookie.encode()).decode() == "chocolate-chip"
     assert response.cookies["type"] == "ginger-molasses"


### PR DESCRIPTION
Whilst browsers won't store the old value, we shouldn't send the browser the unencrypted value. 

This has the side benefit of mutating the existing cookie, rather than replacing it, which makes the code a little cleaner, and ensures that cookie expiry still passes through (which it didn't before).

The root cause is `set_cookie` not replacing already-set cookies if one already exists - it just adds a `set-cookie` header to the response.